### PR TITLE
#163266711 Create the delete meetup endpoint

### DIFF
--- a/app/api/v2/models/meetup_models.py
+++ b/app/api/v2/models/meetup_models.py
@@ -28,3 +28,10 @@ class Meetups:
             #     abort(400, "Question {} doesn't exist!".format(id) )
             rows = cur.fetchone()
             return rows
+
+    def delete_meetup(self, id):
+        """This methods deletes a meetup from the db based on the its id number."""
+        with conn.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute("DELETE FROM meetups WHERE id = {}".format(id))
+            conn.commit()
+            return {"status": 200, "Message": "Meetup deleted"}

--- a/app/api/v2/views/meetup_views.py
+++ b/app/api/v2/views/meetup_views.py
@@ -35,4 +35,8 @@ class SingleMeetup(Meetup):
         single_meetup = meetups_db.get_one_meetup(id)
         return {"status": 200, "data": single_meetup}
 
-        
+    def delete(self, id):
+        meetups_db.delete_meetup(id)
+        return {"status": 200, "Message": "Meetup {} has been deleted!".format(id)}
+
+

--- a/app/tests/v2/test_meetups.py
+++ b/app/tests/v2/test_meetups.py
@@ -33,6 +33,14 @@ class Testmeetups(unittest.TestCase):
         self.assertEqual(resp.status_code, 201)
         resp = self.client.get('/api/v2/meetups/1', content_type='application/json')
         self.assertEqual(resp.status_code, 200)
+
+    def test_delete_meetups(self):
+        resp = self.client.post('/api/v2/meetups', data=json.dumps(self.meetup), content_type='application/json')
+        self.assertEqual(resp.status_code, 201)
+        resp = self.client.delete('/api/v2/meetups/1', content_type='application/json')
+        self.assertEqual(resp.status_code, 200)
+        resp = json.loads(resp.data)
+        self.assertEqual(resp['Message'], "Meetup 1 has been deleted!")
  
     def tearDown(self):
         print('Dropping Tables')


### PR DESCRIPTION
#### What does this PR do?
This pull request creates the delete meetup API endpoint.
#### Description of task to be completed
* Create a failing test to test that the API fails with an assertion error before writing the functionality code.
* Build out  the `api/v2 /meetups` API endpoint to delete a meetup
* Run your test again to ensure it passes
#### How should this be manually tested?
1. `git clone` this repo. and cd into it.
>`https://github.com/SolomonMacharia/Questioner.git`
2. Create a virtual environment.
>`python3 -m venv env`
3. Activate the virtual environment.
>`source env/bin/activate`
4. Install the requirements.
>`pip install -r requirements.txt`
5. Run the command `pytest` in your terminal to run the test
6. Run the application.
>`flask run`
7. Using postman, test the **DELETE** `api/v2/meetups` endpoint.
#### What are the relevant pivotal tracker stories?
#163266711
#### Screenshots
![screenshot from 2019-01-22 16-19-55](https://user-images.githubusercontent.com/41987551/51538333-0b7ed300-1e62-11e9-91c9-dd7e92604f4d.png)
![screenshot from 2019-01-22 16-20-39](https://user-images.githubusercontent.com/41987551/51538276-e8ecba00-1e61-11e9-90d9-b0de2c9f9998.png)
![screenshot from 2019-01-22 16-21-43](https://user-images.githubusercontent.com/41987551/51538284-f013c800-1e61-11e9-9d31-642b2053e9ea.png)
